### PR TITLE
Changed the gitignore for ignoring the builds folder gen by CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.exe
 *.dat
 *.json
+builds/


### PR DESCRIPTION
* **builds** folder would now be automatically removed from Git version control